### PR TITLE
Fix display of jpeg with luminance subsampling (for instance, if MCU …

### DIFF
--- a/ImgDecode.cpp
+++ b/ImgDecode.cpp
@@ -3364,7 +3364,7 @@ void CimgDecode::DecodeScanImg(unsigned nStart,bool bDisplay,bool bQuiet)
 
 						// Store fullres value
 						if (bDisplay)
-							SetFullRes(nMcuX,nMcuY,nComp,0,0,m_nDcChrCb);
+							SetFullRes(nMcuX,nMcuY,nComp,nCssIndH,nCssIndV,m_nDcChrCb);
 
 					}
 				}
@@ -3396,7 +3396,7 @@ void CimgDecode::DecodeScanImg(unsigned nStart,bool bDisplay,bool bQuiet)
 
 						// Store fullres value
 						if (bDisplay)
-							SetFullRes(nMcuX,nMcuY,nComp,0,0,m_nDcChrCr);
+							SetFullRes(nMcuX,nMcuY,nComp,nCssIndH,nCssIndV,m_nDcChrCr);
 
 					}
 				}


### PR DESCRIPTION
…is Y=1x1, Cb=2x2, Cr=2x2).

Missing offset inside the MCU for the chroma components. For isntance, for the case where MCU is Y=1x1, Cb=2x2, Cr=2x2, the four 8x8 chrominance blocks ended up being written at the same location, thus most of the picture appeared in grayscale.