### PR TITLE
Fix user signature database storing

### DIFF
--- a/JPEGsnoop.vcxproj
+++ b/JPEGsnoop.vcxproj
@@ -14,17 +14,18 @@
     <ProjectGuid>{B2881D75-41FE-4A97-90B3-AB8B6BD4ACB3}</ProjectGuid>
     <RootNamespace>JPEGsnoop</RootNamespace>
     <Keyword>MFCProj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/source/DbSigs.cpp
+++ b/source/DbSigs.cpp
@@ -729,6 +729,7 @@ void CDbSigs::DatabaseExtraAdd(CString strExifMake,CString strExifModel,
 	}
 
 		// Now append it to the local database and resave
+		m_sSigListExtra[m_nSigListExtraNum].bValid = true;
 		m_sSigListExtra[m_nSigListExtraNum].strXMake    = strExifMake;
 		m_sSigListExtra[m_nSigListExtraNum].strXModel   = strExifModel;
 		m_sSigListExtra[m_nSigListExtraNum].strUmQual   = strQual;
@@ -860,7 +861,6 @@ void CDbSigs::SetEntryValid(unsigned nInd,bool bValid)
 	ASSERT(nInd < m_nSigListExtraNum);
 	m_sSigListExtra[nInd].bValid = bValid;
 }
-
 
 unsigned CDbSigs::GetIjgNum()
 {


### PR DESCRIPTION
Related to https://github.com/ImpulseAdventure/JPEGsnoop/issues/56

When trying to save multiple signatures like remove one then add another, all with the same program instance open, the user database is not saved correctly.
This change seems to fix it.